### PR TITLE
[DO NOT MERGE] remove TELFE-211 and use main

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,4 +1,5 @@
-name: Build and push generic producer to docker hub
+# Build and push generic producer to docker hub
+name: publish.yaml
 
 on:
   # push:
@@ -18,7 +19,7 @@ on:
 
 jobs:
   publish_api:
-   uses: telicent-oss/shared-workflows/.github/workflows/docker-push-to-registries.yml@TELFE-211/scan-secrets
+   uses: telicent-oss/shared-workflows/.github/workflows/docker-push-to-registries.yml@main
    with:
       APP_NAME: generic-file-adapter
       DOCKERFILE: Dockerfile


### PR DESCRIPTION
This branch of the workflow has FE-only features.
I am finally getting around to merging it into main.

Note: A specific feature is disabling of mutable (aka "non-specific")  tags  
e.g. FE images are not allowed to use`latest` or `alpha`
If that is not required for this repo - and you can use, and want to use mutable tags - then we should remove that param

ℹ️  This cannot be merged until https://github.com/telicent-oss/shared-workflows/pull/45
